### PR TITLE
Add support for transliteration with Israeli pronunciation

### DIFF
--- a/src/pyluach/dates.py
+++ b/src/pyluach/dates.py
@@ -215,7 +215,7 @@ class BaseDate(abc.ABC):
                 return str(day)
         return ''
 
-    def fast_day(self, hebrew=False):
+    def fast_day(self, hebrew=False, transliteration=utils.Pronunciation.ASHKENAZ):
         """Return name of fast day of date.
 
         Parameters
@@ -224,20 +224,25 @@ class BaseDate(abc.ABC):
             ``True`` if you want the fast day name in Hebrew letters. Default
             is ``False``, which returns the name transliterated into English.
 
+        transliteration : enum, optional
+            Determines which style of pronunciation English spellings should follow
+            Default is ``Pronunciation.ASHKENAZ`` for backward compatibility with the original pyluach implementation
+
         Returns
         -------
         str or None
             The name of the fast day or ``None`` if the date is not
             a fast day.
         """
-        return utils._fast_day_string(self, hebrew)
+        return utils._fast_day_string(self, hebrew, transliteration)
 
     def festival(
         self,
         israel=False,
         hebrew=False,
         include_working_days=True,
-        prefix_day=False
+        prefix_day=False,
+        transliteration=utils.Pronunciation.ASHKENAZ
     ):
         """Return name of Jewish festival of date.
 
@@ -259,6 +264,9 @@ class BaseDate(abc.ABC):
         prefix_day : bool, optional
             ``True`` to prefix multi day festivals with the day of the
             festival. Default is ``False``.
+        transliteration : enum, optional
+            Determines which style of pronunciation English spellings should follow
+            Default is ``Pronunciation.ASHKENAZ`` for backward compatibility with the original pyluach implementation
 
         Returns
         -------
@@ -278,7 +286,7 @@ class BaseDate(abc.ABC):
         'Shavuos'
         """
         name = utils._festival_string(
-            self, israel, hebrew, include_working_days
+            self, israel, hebrew, include_working_days, transliteration
         )
         if prefix_day and name is not None:
             day = self._day_of_holiday(israel=israel, hebrew=hebrew)
@@ -286,7 +294,7 @@ class BaseDate(abc.ABC):
                 return f'{day} {name}'
         return name
 
-    def holiday(self, israel=False, hebrew=False, prefix_day=False):
+    def holiday(self, israel=False, hebrew=False, prefix_day=False, transliteration=utils.Pronunciation.ASHKENAZ):
         """Return name of Jewish holiday of the date.
 
         The holidays include the major and minor religious Jewish
@@ -303,6 +311,9 @@ class BaseDate(abc.ABC):
         prefix_day : bool, optional
             ``True`` to prefix multi day holidays with the day of the
             holiday. Default is ``False``.
+        transliteration : enum, optional
+            Determines which style of pronunciation English spellings should follow
+            Default is ``Pronunciation.ASHKENAZ`` for backward compatibility with the original pyluach implementation
 
         Returns
         -------
@@ -322,8 +333,8 @@ class BaseDate(abc.ABC):
         'Taanis Esther'
         """
         return (
-            self.fast_day(hebrew=hebrew)
-            or self.festival(israel, hebrew, prefix_day=prefix_day)
+            self.fast_day(hebrew=hebrew, transliteration=transliteration)
+            or self.festival(israel, hebrew, prefix_day=prefix_day, transliteration=transliteration)
         )
 
 
@@ -747,13 +758,14 @@ class HebrewDate(BaseDate, CalendarDateMixin):
 
     ====== ======= ===========================================================
     Format Example Meaning
-    ====== ======= ===========================================================
+    ====== ======= =========================================================================
     %a     Sun     Weekday as locale's abbreviated name
     %A     Sunday  Weekday as locale's full name
     %w     1       Weekday as decimal number 1-7 Sunday-Shabbos
     %d     07      Day of the month as a 0-padded 2 digit decimal number
     %-d    7       Day of the month as a decimal number
-    %B     Iyar    Month name transliterated into English
+    %B     Teves   Month name transliterated into English following Ashkenazi pronunciation
+    %C     Tevet   Month name transliterated into English following Israeli pronunciation
     %m     02      Month as a 0-padded 2 digit decimal number
     %-m    2       Month as a decimal number
     %y     82, 01  Year without century as a zero-padded decimal number
@@ -766,7 +778,7 @@ class HebrewDate(BaseDate, CalendarDateMixin):
     %*y    תשפ״ב   Year in Hebrew numerals without the thousands place
     %*Y    ה'תשפ״ב Year in Hebrew numerals with the thousands place
     %%     %       A literal '%' character
-    ====== ======= ===========================================================
+    ====== ======= =========================================================================
 
     Example
     -------
@@ -895,6 +907,8 @@ class HebrewDate(BaseDate, CalendarDateMixin):
                         new.append(format(self.day, '02d'))
                     elif curr == 'B':
                         new.append(self.month_name(False))
+                    elif curr == 'C':
+                        new.append(self.month_name(False, transliteration=utils.Pronunciation.MODERN_ISRAELI))
                     elif curr == 'm':
                         new.append(format(self.month, '02d'))
                     elif curr.casefold() == 'y':
@@ -993,7 +1007,7 @@ class HebrewDate(BaseDate, CalendarDateMixin):
     def to_heb(self):
         return self
 
-    def month_name(self, hebrew=False):
+    def month_name(self, hebrew=False, transliteration=utils.Pronunciation.ASHKENAZ):
         """Return the name of the month.
 
         Parameters
@@ -1002,12 +1016,15 @@ class HebrewDate(BaseDate, CalendarDateMixin):
             ``True`` if the month name should be in Hebrew characters.
             Default is ``False`` which returns the month name
             transliterated into English.
+        transliteration : enum, optional
+            Determines which style of pronunciation English spellings should follow
+            Default is ``Pronunciation.ASHKENAZ`` for backward compatibility with the original pyluach implementation
 
         Returns
         -------
         str
         """
-        return utils._month_name(self.year, self.month, hebrew)
+        return utils._month_name(self.year, self.month, hebrew, transliteration)
 
     def hebrew_day(self, withgershayim=True):
         """Return the day of the month in Hebrew letters.

--- a/src/pyluach/dates.py
+++ b/src/pyluach/dates.py
@@ -215,7 +215,7 @@ class BaseDate(abc.ABC):
                 return str(day)
         return ''
 
-    def fast_day(self, hebrew=False, transliteration=utils.Pronunciation.ASHKENAZ):
+    def fast_day(self, hebrew=False, transliteration=utils.Transliteration.ASHKENAZ):
         """Return name of fast day of date.
 
         Parameters
@@ -225,8 +225,8 @@ class BaseDate(abc.ABC):
             is ``False``, which returns the name transliterated into English.
 
         transliteration : enum, optional
-            Determines which style of pronunciation English spellings should follow
-            Default is ``Pronunciation.ASHKENAZ`` for backward compatibility with the original pyluach implementation
+            Determines which style of transliteration English spellings should follow
+            Default is ``utils.Transliteration.ASHKENAZ`` for backward compatibility with the original pyluach implementation
 
         Returns
         -------
@@ -242,7 +242,7 @@ class BaseDate(abc.ABC):
         hebrew=False,
         include_working_days=True,
         prefix_day=False,
-        transliteration=utils.Pronunciation.ASHKENAZ
+        transliteration=utils.Transliteration.ASHKENAZ
     ):
         """Return name of Jewish festival of date.
 
@@ -265,8 +265,8 @@ class BaseDate(abc.ABC):
             ``True`` to prefix multi day festivals with the day of the
             festival. Default is ``False``.
         transliteration : enum, optional
-            Determines which style of pronunciation English spellings should follow
-            Default is ``Pronunciation.ASHKENAZ`` for backward compatibility with the original pyluach implementation
+            Determines which style of transliteration English spellings should follow
+            Default is ``utils.Transliteration.ASHKENAZ`` for backward compatibility with the original pyluach implementation
 
         Returns
         -------
@@ -294,7 +294,7 @@ class BaseDate(abc.ABC):
                 return f'{day} {name}'
         return name
 
-    def holiday(self, israel=False, hebrew=False, prefix_day=False, transliteration=utils.Pronunciation.ASHKENAZ):
+    def holiday(self, israel=False, hebrew=False, prefix_day=False, transliteration=utils.Transliteration.ASHKENAZ):
         """Return name of Jewish holiday of the date.
 
         The holidays include the major and minor religious Jewish
@@ -312,8 +312,8 @@ class BaseDate(abc.ABC):
             ``True`` to prefix multi day holidays with the day of the
             holiday. Default is ``False``.
         transliteration : enum, optional
-            Determines which style of pronunciation English spellings should follow
-            Default is ``Pronunciation.ASHKENAZ`` for backward compatibility with the original pyluach implementation
+            Determines which style of transliteration English spellings should follow
+            Default is ``utils.Transliteration.ASHKENAZ`` for backward compatibility with the original pyluach implementation
 
         Returns
         -------
@@ -764,8 +764,8 @@ class HebrewDate(BaseDate, CalendarDateMixin):
     %w     1       Weekday as decimal number 1-7 Sunday-Shabbos
     %d     07      Day of the month as a 0-padded 2 digit decimal number
     %-d    7       Day of the month as a decimal number
-    %B     Teves   Month name transliterated into English following Ashkenazi pronunciation
-    %C     Tevet   Month name transliterated into English following Israeli pronunciation
+    %B     Teves   Month name transliterated into English following Ashkenazi transliteration
+    %C     Tevet   Month name transliterated into English following Israeli transliteration
     %m     02      Month as a 0-padded 2 digit decimal number
     %-m    2       Month as a decimal number
     %y     82, 01  Year without century as a zero-padded decimal number
@@ -908,7 +908,7 @@ class HebrewDate(BaseDate, CalendarDateMixin):
                     elif curr == 'B':
                         new.append(self.month_name(False))
                     elif curr == 'C':
-                        new.append(self.month_name(False, transliteration=utils.Pronunciation.MODERN_ISRAELI))
+                        new.append(self.month_name(False, transliteration=utils.Transliteration.MODERN_ISRAELI))
                     elif curr == 'm':
                         new.append(format(self.month, '02d'))
                     elif curr.casefold() == 'y':
@@ -1007,7 +1007,7 @@ class HebrewDate(BaseDate, CalendarDateMixin):
     def to_heb(self):
         return self
 
-    def month_name(self, hebrew=False, transliteration=utils.Pronunciation.ASHKENAZ):
+    def month_name(self, hebrew=False, transliteration=utils.Transliteration.ASHKENAZ):
         """Return the name of the month.
 
         Parameters
@@ -1017,8 +1017,8 @@ class HebrewDate(BaseDate, CalendarDateMixin):
             Default is ``False`` which returns the month name
             transliterated into English.
         transliteration : enum, optional
-            Determines which style of pronunciation English spellings should follow
-            Default is ``Pronunciation.ASHKENAZ`` for backward compatibility with the original pyluach implementation
+            Determines which style of transliteration English spellings should follow
+            Default is ``utils.Transliteration.ASHKENAZ`` for backward compatibility with the original pyluach implementation
 
         Returns
         -------

--- a/src/pyluach/hebrewcal.py
+++ b/src/pyluach/hebrewcal.py
@@ -386,7 +386,7 @@ class Month:
         """Return month number 1-12 or 13, Tishrei - Elul."""
         return list(Year(self.year)).index(self.month) + 1
 
-    def month_name(self, hebrew=False):
+    def month_name(self, hebrew=False, transliteration=utils.Transliteration.ASHKENAZ):
         """Return the name of the month.
 
         Replaces `name` attribute.
@@ -396,13 +396,17 @@ class Month:
         hebrew : bool, optional
             `True` if the month name should be written with Hebrew letters
             and False to be transliterated into English using the Ashkenazic
-            pronunciation. Default is `False`.
+            Transliteration. Default is `False`.
+
+        transliteration : enum, optional
+            Determines which style of Transliteration English spellings should follow
+            Default is ``utils.Transliteration.ASHKENAZ`` for backward compatibility with the original pyluach implementation
 
         Returns
         -------
         str
         """
-        return utils._month_name(self.year, self.month, hebrew)
+        return utils._month_name(self.year, self.month, hebrew, transliteration=transliteration)
 
     def month_string(self, thousands=False):
         """Return month and year in Hebrew.
@@ -574,6 +578,10 @@ class HebrewCalendar(calendar.Calendar):
     hebrewyear : bool, optional
         ``True`` to show the year in Hebrew numerals. Default is ``False``,
         which shows the year as a decimal number.
+    transliteration : enum, optional
+        Determines which style of Transliteration English spellings should follow
+        Default is ``utils.Transliteration.ASHKENAZ`` for backward compatibility with the original pyluach implementation
+
 
     Attributes
     ----------
@@ -581,6 +589,7 @@ class HebrewCalendar(calendar.Calendar):
     hebrewweekdays : bool
     hebrewmonths : bool
     hebrewyear : bool
+    transliteration: enum
 
     Note
     ----
@@ -591,7 +600,7 @@ class HebrewCalendar(calendar.Calendar):
 
     def __init__(
         self, firstweekday=1, hebrewnumerals=True, hebrewweekdays=False,
-        hebrewmonths=False, hebrewyear=False
+        hebrewmonths=False, hebrewyear=False, transliteration=utils.Transliteration.ASHKENAZ
     ):
         if not 1 <= firstweekday <= 7:
             raise IllegalWeekdayError(firstweekday)
@@ -601,6 +610,7 @@ class HebrewCalendar(calendar.Calendar):
         self.hebrewweekdays = hebrewweekdays
         self.hebrewmonths = hebrewmonths
         self.hebrewyear = hebrewyear
+        self.transliteration = transliteration
 
     @property
     def firstweekday(self):
@@ -866,6 +876,9 @@ class HebrewHTMLCalendar(HebrewCalendar, calendar.HTMLCalendar):
     rtl : bool, optional
         ``True``  to arrange the months and the days of the month from
         right to left. Default is ``False``.
+    transliteration : enum, optional
+        Determines which style of Transliteration English spellings should follow
+        Default is ``utils.Transliteration.ASHKENAZ`` for backward compatibility with the original pyluach implementation
 
     Attributes
     ----------
@@ -878,7 +891,7 @@ class HebrewHTMLCalendar(HebrewCalendar, calendar.HTMLCalendar):
 
     def __init__(
         self, firstweekday=1, hebrewnumerals=True, hebrewweekdays=False,
-        hebrewmonths=False, hebrewyear=False, rtl=False
+        hebrewmonths=False, hebrewyear=False, rtl=False, transliteration=utils.Transliteration.ASHKENAZ
     ):
         self.rtl = rtl
         super().__init__(
@@ -886,7 +899,8 @@ class HebrewHTMLCalendar(HebrewCalendar, calendar.HTMLCalendar):
             hebrewnumerals,
             hebrewweekdays,
             hebrewmonths,
-            hebrewyear
+            hebrewyear,
+            transliteration
         )
 
     def _rtl_str(self):
@@ -969,7 +983,7 @@ class HebrewHTMLCalendar(HebrewCalendar, calendar.HTMLCalendar):
         ------
         str
         """
-        s = Month(theyear, themonth).month_name(self.hebrewmonths)
+        s = Month(theyear, themonth).month_name(self.hebrewmonths, transliteration=self.transliteration)
         if withyear:
             s = f'{s} {self.formatyearnumber(theyear)}'
         return (
@@ -999,7 +1013,7 @@ class HebrewHTMLCalendar(HebrewCalendar, calendar.HTMLCalendar):
             f'class="{self.cssclass_month}"{self._rtl_str()}>'
         )
         a('\n')
-        a(self.formatmonthname(theyear, themonth, withyear=withyear))
+        a(self.formatmonthname(theyear, themonth, withyear=withyear, transliteration=self.transliteration))
         a('\n')
         a(self.formatweekheader())
         a('\n')
@@ -1045,7 +1059,7 @@ class HebrewHTMLCalendar(HebrewCalendar, calendar.HTMLCalendar):
             for m in months:
                 a('<td>')
                 a(self.formatmonth(
-                    theyear, yearmonths[m-1], withyear=False
+                    theyear, yearmonths[m-1], withyear=False, transliteration=self.transliteration
                 ))
                 a('</td>')
             a('</tr>')
@@ -1159,7 +1173,7 @@ class HebrewTextCalendar(HebrewCalendar, calendar.TextCalendar):
         -------
         str
         """
-        s = Month(theyear, themonth).month_name(self.hebrewmonths)
+        s = Month(theyear, themonth).month_name(self.hebrewmonths, transliteration=self.transliteration)
         if withyear:
             if self.hebrewyear:
                 year = to_hebrew_numeral(theyear)
@@ -1202,7 +1216,7 @@ class HebrewTextCalendar(HebrewCalendar, calendar.TextCalendar):
             months = range(m*i+1, min(m*(i+1)+1, len(yearmonths)+1))
             a('\n'*l)
             names = (
-                self.formatmonthname(theyear, yearmonths[k-1], colwidth, False)
+                self.formatmonthname(theyear, yearmonths[k-1], colwidth, False, transliteration=self.transliteration)
                 for k in months
             )
             a(calendar.formatstring(names, colwidth, c).rstrip())
@@ -1224,7 +1238,7 @@ class HebrewTextCalendar(HebrewCalendar, calendar.TextCalendar):
         return ''.join(v)
 
 
-def fast_day(date, hebrew=False):
+def fast_day(date, hebrew=False, transliteration=utils.Transliteration.ASHKENAZ):
     """Return name of fast day or None.
 
     Parameters
@@ -1234,6 +1248,9 @@ def fast_day(date, hebrew=False):
     hebrew : bool, optional
         ``True`` if you want the fast_day name in Hebrew letters. Default
         is ``False``, which returns the name transliterated into English.
+    transliteration : enum, optional
+        Determines which style of transliteration English spellings should follow
+        Default is ``utils.Transliteration.ASHKENAZ`` for backward compatibility with the original pyluach implementation    
 
     Returns
     -------
@@ -1241,7 +1258,7 @@ def fast_day(date, hebrew=False):
         The name of the fast day or ``None`` if the given date is not
         a fast day.
     """
-    return date.fast_day(hebrew)
+    return date.fast_day(hebrew, transliteration=transliteration)
 
 
 def festival(
@@ -1249,7 +1266,8 @@ def festival(
     israel=False,
     hebrew=False,
     include_working_days=True,
-    prefix_day=False
+    prefix_day=False,
+    transliteration=utils.Transliteration.ASHKENAZ
 ):
     """Return Jewish festival of given day.
 
@@ -1274,6 +1292,9 @@ def festival(
     prefix_day : bool, optional
         ``True`` to prefix multi day festivals with the day of the
         festival. Default is ``False``.
+    transliteration : enum, optional
+        Determines which style of transliteration English spellings should follow
+        Default is ``utils.Transliteration.ASHKENAZ`` for backward compatibility with the original pyluach implementation
 
     Returns
     -------
@@ -1293,10 +1314,10 @@ def festival(
     >>> festival(shavuos, israel=True, prefix_day=True)
     'Shavuos'
     """
-    return date.festival(israel, hebrew, include_working_days, prefix_day)
+    return date.festival(israel, hebrew, include_working_days, prefix_day, transliteration=transliteration)
 
 
-def holiday(date, israel=False, hebrew=False, prefix_day=False):
+def holiday(date, israel=False, hebrew=False, prefix_day=False, transliteration=utils.Transliteration.ASHKENAZ):
     """Return Jewish holiday of given date.
 
     The holidays include the major and minor religious Jewish
@@ -1315,6 +1336,9 @@ def holiday(date, israel=False, hebrew=False, prefix_day=False):
     prefix_day : bool, optional
         ``True`` to prefix multi day holidays with the day of the
         holiday. Default is ``False``.
+    transliteration : enum, optional
+        Determines which style of transliteration English spellings should follow
+        Default is ``utils.Transliteration.ASHKENAZ`` for backward compatibility with the original pyluach implementation
 
     Returns
     -------
@@ -1334,4 +1358,4 @@ def holiday(date, israel=False, hebrew=False, prefix_day=False):
     >>> holiday(taanis_esther, prefix_day=True)
     'Taanis Esther'
     """
-    return date.holiday(israel, hebrew, prefix_day)
+    return date.holiday(israel, hebrew, prefix_day, transliteration=transliteration)

--- a/src/pyluach/parshios.py
+++ b/src/pyluach/parshios.py
@@ -16,18 +16,17 @@ Note
 The algorithm is based on Dr. Irv Bromberg's, University of Toronto at
 http://individual.utoronto.ca/kalendis/hebrew/parshah.htm
 
-All English parsha names are transliterated into the American Ashkenazik
-pronunciation.
+Several options are available for style of transliteration; the default is American Ashkenazik.
 
 
 Attributes
 ----------
 PARSHIOS_ASHKENAZ : list of str
-    A list of the parshios transliterated into English, with Ashkenasic pronunciation.
+    A list of the parshios transliterated into English, with Ashkenasic transliteration.
 PARSHIOS_ISRAELI_1 : list of str
-    A list of the parshios transliterated into English, with mixed Israeli pronunciation.
+    A list of the parshios transliterated into English, with mixed Israeli transliteration.
 PARSHIOS_ISRAELI_2 : list of str
-    A list of the parshios transliterated into English, with modern Israeli pronunciation.
+    A list of the parshios transliterated into English, with modern Israeli transliteration.
 PARSHIOS_HEBREW : list of str
     A list of the parshios in Hebrew.
 """
@@ -36,7 +35,7 @@ from collections import deque, OrderedDict
 from functools import lru_cache
 
 from pyluach.dates import HebrewDate
-from pyluach.utils import _is_leap, Pronunciation
+from pyluach.utils import _is_leap, Transliteration
 
 
 PARSHIOS_ASHKENAZ = [
@@ -85,9 +84,9 @@ PARSHIOS_HEBREW = [
     'נצבים', 'וילך', 'האזינו', 'וזאת הברכה'
 ]
 
-PARSHA_NAMES_IN_EN = {Pronunciation.ASHKENAZ: PARSHIOS_ASHKENAZ, 
-                      Pronunciation.MIXED_ISRAELI: PARSHIOT_ISRAELI_MIXED, 
-                      Pronunciation.MODERN_ISRAELI: PARSHIOT_ISRAELI_MODERN}
+PARSHA_NAMES_IN_EN = {Transliteration.ASHKENAZ: PARSHIOS_ASHKENAZ, 
+                      Transliteration.MIXED_ISRAELI: PARSHIOT_ISRAELI_MIXED, 
+                      Transliteration.MODERN_ISRAELI: PARSHIOT_ISRAELI_MODERN}
 
 def _parshaless(date, israel=False):
     if israel and date.tuple()[1:] in [(7, 23), (1, 22), (3, 7)]:
@@ -167,7 +166,7 @@ def getparsha(date, israel=False):
     return table[shabbos]
 
 
-def getparsha_string(date, israel=False, hebrew=False, transliteration=Pronunciation.ASHKENAZ):
+def getparsha_string(date, israel=False, hebrew=False, transliteration=Transliteration.ASHKENAZ):
     """Return the parsha as a string for the given date.
 
     This function wraps ``getparsha`` returning the parsha name.
@@ -186,8 +185,8 @@ def getparsha_string(date, israel=False, hebrew=False, transliteration=Pronuncia
       Default is ``False``.
 
     transliteration : enum, optional
-      Determines which style of pronunciation English spellings should follow
-      Default is ``Pronunciation.ASHKENAZ`` for backward compatibility with the original pyluach implementation
+      Determines which style of transliteration English spellings should follow
+      Default is ``utils.Transliteration.ASHKENAZ`` for backward compatibility with the original pyluach implementation
 
     Returns
     -------

--- a/src/pyluach/utils.py
+++ b/src/pyluach/utils.py
@@ -6,6 +6,11 @@ from functools import lru_cache
 from enum import Enum
 
 
+class Pronunciation(Enum):
+    ASHKENAZ = "Ashkenaz"
+    MIXED_ISRAELI = "Mixed Israeli"
+    MODERN_ISRAELI = "Modern Israeli"
+
 class _Days(Enum):
     ROSH_HASHANA = 'Rosh Hashana'
     YOM_KIPPUR = 'Yom Kippur'
@@ -52,10 +57,23 @@ _days_hebrew = {
     _Days.NINTH_OF_AV: 'ט׳ באב'
 }
 
+_days_israeli_en = {k:k.value for k in _Days}
+_days_israeli_en.update({
+    _Days.SUCCOS: 'Sukkot',
+    _Days.SHMINI_ATZERES: 'Shmini Atzeret',
+    _Days.SIMCHAS_TORAH: 'Simchat Torah',
+    _Days.SHAVUOS: 'Shavuot',
+    _Days.TENTH_OF_TEVES: '10th of Tevet',
+    _Days.TAANIS_ESTHER: "Ta'anit Esther",
+})
 
 MONTH_NAMES = [
     'Nissan', 'Iyar', 'Sivan', 'Tammuz', 'Av', 'Elul', 'Tishrei', 'Cheshvan',
     'Kislev', 'Teves', 'Shevat', 'Adar', 'Adar 1', 'Adar 2']
+
+MONTH_NAMES_ISRAELI_EN = [
+    'Nissan', 'Iyar', 'Sivan', 'Tammuz', 'Av', 'Elul', 'Tishrei', 'Cheshvan',
+    'Kislev', 'Tevet', 'Shvat', 'Adar', 'Adar 1', 'Adar 2']
 
 MONTH_NAMES_HEBREW = [
     'ניסן', 'אייר', 'סיון', 'תמוז', 'אב', 'אלול', 'תשרי', 'חשון', 'כסלו',
@@ -63,6 +81,9 @@ MONTH_NAMES_HEBREW = [
 
 FAST_DAYS = [
     'Tzom Gedalia', '10 of Teves', 'Taanis Esther', '17 of Tamuz', '9 of Av']
+
+FAST_DAYS_ISRAELI_EN = [
+    'Tzom Gedalia', '10th of Tevet', 'Taanit Esther', '17 of Tamuz', '9 of Av']
 
 FAST_DAYS_HEBREW = [
     'צום גדליה', 'י׳ בטבת', 'תענית אסתר', 'י״ז בתמוז', 'ט׳ באב']
@@ -72,6 +93,10 @@ FESTIVALS = [
     'Chanuka', "Tu B'shvat", 'Purim Katan', 'Purim', 'Shushan Purim',
     'Pesach', 'Pesach Sheni', "Lag Ba'omer", 'Shavuos', "Tu B'av"]
 
+FESTIVALS_ISRAELI_EN = [
+    'Rosh Hashana', 'Yom Kippur', 'Sukkot', 'Shmini Atzeret', 'Simchat Torah',
+    'Chanuka', "Tu B'shvat", 'Purim Katan', 'Purim', 'Shushan Purim',
+    'Pesach', 'Pesach Sheni', "Lag Ba'omer", 'Shavuot', "Tu B'av"]
 
 FESTIVALS_HEBREW = [
     'ראש השנה', 'יום כיפור', 'סוכות', 'שמיני עצרת', 'שמחת תורה', 'חנוכה',
@@ -166,14 +191,13 @@ def _month_length(year, month):
     raise ValueError('Invalid month')
 
 
-def _month_name(year, month, hebrew):
+def _month_name(year, month, hebrew, transliteration):
     index = month
     if month < 12 or not _is_leap(year):
         index -= 1
     if hebrew:
         return MONTH_NAMES_HEBREW[index]
-    return MONTH_NAMES[index]
-
+    return MONTH_NAMES[index] if transliteration==Pronunciation.ASHKENAZ else MONTH_NAMES_ISRAELI_EN[index]
 
 def _monthslist(year):
     months = [7, 8, 9, 10, 11, 12, 13, 1, 2, 3, 4, 5, 6]
@@ -238,13 +262,13 @@ def _fast_day(date):
     return None
 
 
-def _fast_day_string(date, hebrew=False):
+def _fast_day_string(date, hebrew=False, transliteration=Pronunciation.ASHKENAZ):
     fast = _fast_day(date)
     if fast is None:
         return None
     if hebrew:
         return _days_hebrew[fast]
-    return fast.value
+    return fast.value if transliteration==Pronunciation.ASHKENAZ else _days_israeli_en[fast]
 
 
 def _first_day_of_holiday(holiday):
@@ -352,10 +376,11 @@ def _festival_string(
     israel=False,
     hebrew=False,
     include_working_days=True,
+    transliteration=Pronunciation.ASHKENAZ
 ):
     festival = _festival(date, israel, include_working_days)
     if festival is None:
         return None
     if hebrew:
         return _days_hebrew[festival]
-    return festival.value
+    return festival.value if transliteration==Pronunciation.ASHKENAZ else _days_israeli_en[festival]

--- a/src/pyluach/utils.py
+++ b/src/pyluach/utils.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from enum import Enum
 
 
-class Pronunciation(Enum):
+class Transliteration(Enum):
     ASHKENAZ = "Ashkenaz"
     MIXED_ISRAELI = "Mixed Israeli"
     MODERN_ISRAELI = "Modern Israeli"
@@ -191,13 +191,13 @@ def _month_length(year, month):
     raise ValueError('Invalid month')
 
 
-def _month_name(year, month, hebrew, transliteration):
+def _month_name(year, month, hebrew, transliteration=Transliteration.ASHKENAZ):
     index = month
     if month < 12 or not _is_leap(year):
         index -= 1
     if hebrew:
         return MONTH_NAMES_HEBREW[index]
-    return MONTH_NAMES[index] if transliteration==Pronunciation.ASHKENAZ else MONTH_NAMES_ISRAELI_EN[index]
+    return MONTH_NAMES[index] if transliteration==Transliteration.ASHKENAZ else MONTH_NAMES_ISRAELI_EN[index]
 
 def _monthslist(year):
     months = [7, 8, 9, 10, 11, 12, 13, 1, 2, 3, 4, 5, 6]
@@ -262,13 +262,13 @@ def _fast_day(date):
     return None
 
 
-def _fast_day_string(date, hebrew=False, transliteration=Pronunciation.ASHKENAZ):
+def _fast_day_string(date, hebrew=False, transliteration=Transliteration.ASHKENAZ):
     fast = _fast_day(date)
     if fast is None:
         return None
     if hebrew:
         return _days_hebrew[fast]
-    return fast.value if transliteration==Pronunciation.ASHKENAZ else _days_israeli_en[fast]
+    return fast.value if transliteration==Transliteration.ASHKENAZ else _days_israeli_en[fast]
 
 
 def _first_day_of_holiday(holiday):
@@ -376,11 +376,11 @@ def _festival_string(
     israel=False,
     hebrew=False,
     include_working_days=True,
-    transliteration=Pronunciation.ASHKENAZ
+    transliteration=Transliteration.ASHKENAZ
 ):
     festival = _festival(date, israel, include_working_days)
     if festival is None:
         return None
     if hebrew:
         return _days_hebrew[festival]
-    return festival.value if transliteration==Pronunciation.ASHKENAZ else _days_israeli_en[festival]
+    return festival.value if transliteration==Transliteration.ASHKENAZ else _days_israeli_en[festival]


### PR DESCRIPTION
pyluach is great but Ashkenazi pronunciation / transliteration isn't a fit for every project. I've added support for optionally selecting other transliterations. The original Ashkenazi remains the default for all APIs, so existing clients do not require any change.